### PR TITLE
Add auxiliary model with validator for type-specific usage instructions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 # Repo-specific
-marda_registry/models/*
+marda_registry/models/[A-Za-z0-9]*.py
 
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,5 @@
 ---
-exclude: ^(marda_registry/data/|marda_registry/models/)
+exclude: ^(marda_registry/data/)
 repos:
     - repo: https://github.com/pre-commit/pre-commit-hooks
       rev: v4.6.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,16 +26,13 @@ repos:
           - id: yamllint
             args: [--format, parsable, --strict, -d, '{line-length: {max: 100}}']
 
-    - repo: https://github.com/psf/black
-      rev: 24.3.0
-      hooks:
-          - id: black
-            name: Blacken
 
-    - repo: https://github.com/pycqa/flake8
-      rev: 7.0.0
+    - repo: https://github.com/astral-sh/ruff-pre-commit
+      rev: v0.4.2
       hooks:
-          - id: flake8
+          - id: ruff
+            args: [--fix]
+          - id: ruff-format
 
     - repo: https://github.com/pre-commit/mirrors-mypy
       rev: v1.9.0
@@ -43,9 +40,3 @@ repos:
           - id: mypy
             name: MyPy
             additional_dependencies: [types-all, pydantic~=1.10]
-
-    - repo: https://github.com/PyCQA/isort
-      rev: 5.13.2
-      hooks:
-          - id: isort
-            name: isort

--- a/marda_registry/models/__init__.py
+++ b/marda_registry/models/__init__.py
@@ -3,9 +3,54 @@ from the schemas repository with LinkML and should not
 be edited by hand.
 """
 
-__version__ = "0.0.1"
+from pydantic import validator
 
-from .extractor import Extractor
+from .extractor import Extractor as AutoGenExtractor
 from .filetype import FileType
+
+
+class Extractor(AutoGenExtractor):
+    """A wrapper for the automatically generated Extractor class
+    that includes some additional validators.
+
+    """
+
+    @validator("usage")
+    def check_usage_filetypes(cls, v, values):
+        """Check that any filetype instructions in the usage
+        are defined at the top-level, and that all supported_filetypes
+        values have instructions (or that there is a catch-all).
+
+        """
+
+        if not v:
+            return v
+
+        supported_filetypes: set[str] = set(
+            d.id for d in values.get("supported_filetypes")
+        )
+        usage_to_fts: dict[str, dict] = {}
+
+        bad_fts: list[str] = []
+        for instruction in v:
+            if not instruction.supported_filetypes:
+                for t in supported_filetypes:
+                    if t not in usage_to_fts:
+                        usage_to_fts[t] = instruction
+            else:
+                for t in instruction.supported_filetypes:
+                    usage_to_fts[t] = instruction
+                    if t not in supported_filetypes:
+                        bad_fts.append("Bad filetype {t} found in instruction")
+
+        for t in supported_filetypes:
+            if t not in usage_to_fts:
+                bad_fts.append(f"No instruction for {t}")
+
+        if bad_fts:
+            raise ValueError("Unsupported filetypes: " + "\n".join(bad_fts))
+
+        return v
+
 
 __all__ = ("Extractor", "FileType")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,17 +55,19 @@ dev = [
 repository = "https://github.com/marda-alliance/metadata_extractors_registry"
 
 [tool.ruff]
-select = ["E", "F", "I", "W", "Q"]
-ignore = ["E501", "E402"]
-fixable = ["A", "B", "C", "D", "E", "F", "I"]
-unfixable = []
 extend-exclude = [
     "providers",
 ]
 target-version = "py310"
-per-file-ignores = {}
+
+[tool.ruff.lint]
+select = ["E", "F", "I", "W", "Q"]
+ignore = ["E501", "E402"]
+fixable = ["A", "B", "C", "D", "E", "F", "I"]
+unfixable = []
 # Allow unused variables when underscore-prefixed.
 dummy-variable-rgx = "^(_+|(_+[a-zA-Z0-9_]*[a-zA-Z0-9]+?))$"
+per-file-ignores = {}
 
 [tool.mypy]
 ignore_missing_imports = true

--- a/tasks.py
+++ b/tasks.py
@@ -60,7 +60,6 @@ def validate_entries(_):
             for extractor in entries:
                 for filetype in extractor.supported_filetypes:
                     if filetype.id not in filetype_ids:
-                        breakpoint()
                         errors.append(
                             f"Extractor {extractor.name=} has invalid filetype {filetype.id=}. Should be one of {filetype_ids=}"
                         )


### PR DESCRIPTION
See discussion in https://github.com/marda-alliance/metadata_extractors_schema/issues/49 for why we can't do this directly in LinkML.