### PR TITLE
Add Bruker DIFFRAC.EVA xy `FileType` as `diffrac-eva-xy`

### DIFF
--- a/yard/data/filetypes/diffrac-eva-xy.yml
+++ b/yard/data/filetypes/diffrac-eva-xy.yml
@@ -1,0 +1,18 @@
+---
+id: >-
+    diffrac-eva-xy
+name: >-
+    DIFFRAC.EVA XY export
+description: >-
+    A plain text data file exported by Bruker's DIFFRAC.EVA software, containing a diffraction pattern,
+    optional uncertaintities, and a header with some generic metadata about the experiment.
+associated_file_extensions:
+    - xy
+    - xye
+associated_vendors:
+    - Bruker
+subject:
+    - diffraction
+associated_software:
+    - Bruker EVA.DIFFRAC
+

--- a/yard/data/lfs/diffrac-eva-xy/diffrac-eva-example.xy
+++ b/yard/data/lfs/diffrac-eva-xy/diffrac-eva-example.xy
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ef27e90105c7fd30221b0adcf637ebd0d50269ad3f2e00814b7fe7575c0dda25
+size 95634


### PR DESCRIPTION
This PR adds Bruker DIFFRAC.EVA, as described in the registry entry.

It stuffs some metadata in the header in a slightly annoying way, and is otherwise the same as a normal xy file:

```
'Id: "" Comment: "" Operator: "Emmy Noether" Anode: "Cu" Scantype: "Coupled TwoTheta/Theta" TimePerStep: "96"'
1.0000 2.00000
```

