### PR TITLE
Add navani extractor

### DIFF
--- a/yard/data/extractors/navani.yml
+++ b/yard/data/extractors/navani.yml
@@ -1,0 +1,35 @@
+---
+id: >-
+    navani 
+name: >-
+    navani
+description: >-
+    Module for processing and plotting electrochemical data from battery cyclers. Contains functions to extract dQ/dV. 
+supported_filetypes:
+    - id: biologic-mpr
+    - id: neware-nda
+    - id: landt-excel
+    - id: arbin-excel
+    - id: arbin-res
+    - id: ivium-txt
+license:
+    spdx: MIT
+subject:
+    - electrochemistry
+    - voltammetry
+citations:
+    - uri: https://github.com/be-smith/navani
+      creators:
+          - B. Smith
+      title: navani github repository
+      type: software
+source_repository: https://github.com/be-smith/navani
+usage:
+    - method: python
+      setup: navani 
+      command: navani.echem.echem_file_loader({{ input_path }})
+installation:
+    - method: pip
+      packages:
+          - navani ~= 0.1
+      requires_python: '>=3.10'

--- a/yard/data/extractors/navani.yml
+++ b/yard/data/extractors/navani.yml
@@ -5,14 +5,12 @@ name: >-
     navani
 description: >-
     Module for processing and plotting electrochemical data from battery cyclers.
-    Contains functions to extract dQ/dV.
+    Contains functions to extract dQ/dV. Also supports Excel and text outputs from
+    Arbin and Landt.
 supported_filetypes:
     - id: biologic-mpr
     - id: neware-nda
-    - id: landt-excel
-    - id: arbin-excel
     - id: arbin-res
-    - id: ivium-txt
 license:
     spdx: MIT
 subject:

--- a/yard/data/extractors/navani.yml
+++ b/yard/data/extractors/navani.yml
@@ -14,7 +14,6 @@ supported_filetypes:
       description: >-
           Note: Arbin .res extraction requires the `mdbtools` (https://github.com/mdbtools/mdbtools)
           executable to be available at runtime.
-
 license:
     spdx: MIT
 subject:

--- a/yard/data/extractors/navani.yml
+++ b/yard/data/extractors/navani.yml
@@ -1,6 +1,6 @@
 ---
 id: >-
-    navani 
+    navani
 name: >-
     navani
 description: >-

--- a/yard/data/extractors/navani.yml
+++ b/yard/data/extractors/navani.yml
@@ -4,7 +4,8 @@ id: >-
 name: >-
     navani
 description: >-
-    Module for processing and plotting electrochemical data from battery cyclers. Contains functions to extract dQ/dV. 
+    Module for processing and plotting electrochemical data from battery cyclers.
+    Contains functions to extract dQ/dV.
 supported_filetypes:
     - id: biologic-mpr
     - id: neware-nda
@@ -26,7 +27,7 @@ citations:
 source_repository: https://github.com/be-smith/navani
 usage:
     - method: python
-      setup: navani 
+      setup: navani
       command: navani.echem.echem_file_loader({{ input_path }})
 installation:
     - method: pip

--- a/yard/data/extractors/navani.yml
+++ b/yard/data/extractors/navani.yml
@@ -11,6 +11,10 @@ supported_filetypes:
     - id: biologic-mpr
     - id: neware-nda
     - id: arbin-res
+      description: >-
+          Note: Arbin .res extraction requires the `mdbtools` (https://github.com/mdbtools/mdbtools)
+          executable to be available at runtime.
+
 license:
     spdx: MIT
 subject:


### PR DESCRIPTION
navani has recently been released on PyPI, so thought I should add it here. It also supports several poorly-defined file formats that we might want to add (with IDs hinted at in this PR), for example excel/sqlite/txt exports from various cycler brands. Want to see how the CI responds right now if an extractor tries to announce that it supports a file type we don't yet have, so haven't included these yet.