### PR TITLE
yaml lint the database

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,5 @@
 ---
-exclude: ^(yard/data/)
+exclude: ^(yard/data/lfs)
 repos:
     - repo: https://github.com/pre-commit/pre-commit-hooks
       rev: v4.6.0

--- a/yard/data/extractors/galvani.yml
+++ b/yard/data/extractors/galvani.yml
@@ -33,12 +33,12 @@ usage:
       setup: galvani
       command: galvani.BioLogic.MPRfile({{ input_path }}).data
       supported_filetypes:
-        - biologic-mpr
+          - biologic-mpr
     - method: python
       setup: galvani
       command: galvani.BioLogic.MPTfile({{ input_path }})
       supported_filetypes:
-        - biologic-mpt
+          - biologic-mpt
 installation:
     - method: pip
       packages:

--- a/yard/data/extractors/pasta-converters.yml
+++ b/yard/data/extractors/pasta-converters.yml
@@ -24,7 +24,7 @@ citations:
     - uri: https://github.com/PASTA-ELN/Converters
       creators:
           - S. Brinckmann
-      title: 'converters from binary files to hdf5'
+      title: converters from binary files to hdf5
       type: software
 usage:
     - method: cli

--- a/yard/data/extractors/quantumespresso.yml
+++ b/yard/data/extractors/quantumespresso.yml
@@ -1,7 +1,8 @@
 ---
 id: qe-tools
 name: Tools for Quantum ESPRESSO
-description: A set of tools for the Quantum ESPRESSO suite of electronic-structure simulation codes.
+description: A set of tools for the Quantum ESPRESSO suite of electronic-structure
+    simulation codes.
 subject:
     - atomistic simulation
     - electronic structure calculations
@@ -15,12 +16,13 @@ installation:
     - method: pip
       packages:
           - qe-tools>=2.2
-      requires_python: ">=3.8"
+      requires_python: '>=3.8'
 citations:
     - uri: doi:10.1088/0953-8984/21/39/395502
       creators:
           - P. Giannozzi
-      title: "QUANTUM ESPRESSO: a modular and open-source software project for quantum simulations of materials"
+      title: 'QUANTUM ESPRESSO: a modular and open-source software project for quantum
+          simulations of materials'
       type: article
     - uri: https://github.com/aiidateam/qe-tools
       creators:
@@ -31,10 +33,10 @@ supported_filetypes:
     - id: qe-pw-in
       description: An input file for the Quantum ESPRESSO PW package
       template:
-        input_type: PW
+          input_type: PW
     - id: qe-cp-in
       description: An input file for the Quantum ESPRESSO CP package
       template:
-        input_type: CP
+          input_type: CP
 license:
     spdx: GPL2

--- a/yard/data/extractors/rosettasciio.yml
+++ b/yard/data/extractors/rosettasciio.yml
@@ -28,8 +28,8 @@ citations:
       title: HyperSpy
       type: software
       creators:
-        - Francisco de la Peñare
-        - et al.
+          - Francisco de la Peñare
+          - et al.
 source_repository: https://github.com/hyperspy/rosettasciio
 documentation: https://hyperspy.org/rosettasciio
 usage:

--- a/yard/data/extractors/zeiss-tiff-meta.yml
+++ b/yard/data/extractors/zeiss-tiff-meta.yml
@@ -18,7 +18,7 @@ citations:
     - uri: https://github.com/ks00x/zeiss_tiff_meta
       creators:
           - K. Schwarzburg
-      title: 'zeiss_tiff_meta github repository'
+      title: zeiss_tiff_meta github repository
       type: software
 usage:
     - method: python

--- a/yard/data/filetypes/biologic-mpr.yml
+++ b/yard/data/filetypes/biologic-mpr.yml
@@ -40,4 +40,3 @@ associated_instruments:
     - BioLogic VMP-300
 associated_software:
     - BioLogic EC-Lab
-

--- a/yard/data/filetypes/diffrac-eva-xy.yml
+++ b/yard/data/filetypes/diffrac-eva-xy.yml
@@ -4,7 +4,8 @@ id: >-
 name: >-
     DIFFRAC.EVA XY export
 description: >-
-    A plain text data file exported by Bruker's DIFFRAC.EVA software, containing a diffraction pattern,
+    A plain text data file exported by Bruker's DIFFRAC.EVA software, containing a
+    diffraction pattern,
     optional uncertaintities, and a header with some generic metadata about the experiment.
 associated_file_extensions:
     - xy
@@ -15,4 +16,3 @@ subject:
     - diffraction
 associated_software:
     - Bruker EVA.DIFFRAC
-

--- a/yard/data/filetypes/neware-nda.yml
+++ b/yard/data/filetypes/neware-nda.yml
@@ -4,13 +4,13 @@ id: >-
 name: >-
     Neware NDA
 description: >-
-    A binary data file used by Neware cyclers. At least two different versions 
+    A binary data file used by Neware cyclers. At least two different versions
     exist, one with the `.nda` file extension, the other with `.ndax`.
-    From the Neware website: "NDA file is a kind of structured data file. 
-    This kind of file stores testing data and other information including 
+    From the Neware website: "NDA file is a kind of structured data file.
+    This kind of file stores testing data and other information including
     steps once you scheduled and log during testing."
 associated_file_extensions:
-    - nda 
+    - nda
     - ndax
 associated_vendors:
     - Neware
@@ -23,4 +23,3 @@ associated_instruments:
     - CT-4000 series
 associated_software:
     - Neware BTSDA
-

--- a/yard/data/filetypes/qe-cp-in.yml
+++ b/yard/data/filetypes/qe-cp-in.yml
@@ -1,7 +1,8 @@
 ---
 id: qe-cp-in
 name: QE CP input file
-description: An input file for Quantum ESPRESSO's Car-Parrinello (CP) ab-initio molecular dynamics package.
+description: An input file for Quantum ESPRESSO's Car-Parrinello (CP) ab-initio molecular
+    dynamics package.
 associated_file_extensions:
     - in
 subject:

--- a/yard/data/filetypes/rigaku-rasx.yml
+++ b/yard/data/filetypes/rigaku-rasx.yml
@@ -4,7 +4,8 @@ id: >-
 name: >-
     Rigaku .rasx file
 description: >-
-    A ZIP file, containing nested folders storing PXRD patterns in plain text, with measurement
+    A ZIP file, containing nested folders storing PXRD patterns in plain text, with
+    measurement
     metadata as XML.
 associated_file_extensions:
     - rasx


### PR DESCRIPTION
Not sure if this was intentional at some point, but the various linters were not running on the "database" yaml files, whereas I think we only ever meant to exclude the lfs data files. This PR enables pre-commit on the database entries and reformats a load of yaml.