### PR TITLE
Add entry for JCAMP-DX filetype

### DIFF
--- a/yard/data/filetypes/jcamp-dx.yml
+++ b/yard/data/filetypes/jcamp-dx.yml
@@ -1,0 +1,18 @@
+---
+id: >-
+    jcamp-dx
+name: >-
+    JCAMP-DX
+description: >-
+    An IUPAC-endorsed standard for the representation of spectroscopic data and metadata
+    in a textual format with blocks of compressed numerical data encoded as ASCII.
+    It is available as output from several spectroscopic software packages.
+associated_file_extensions:
+    - dx
+    - jdx
+subject:
+    - spectroscopy
+    - infrared spectroscopy
+    - nuclear magnetic resonance spectroscopy
+    - electronc magnetic resonance spectroscopy
+    - mass spectrometry

--- a/yard/data/filetypes/jcamp-dx.yml
+++ b/yard/data/filetypes/jcamp-dx.yml
@@ -13,6 +13,6 @@ associated_file_extensions:
 subject:
     - spectroscopy
     - infrared spectroscopy
-    - nuclear magnetic resonance spectroscopy
-    - electronc magnetic resonance spectroscopy
+    - nuclear magnetic resonance spectrometry
+    - electronc magnetic resonance spectrometry
     - mass spectrometry


### PR DESCRIPTION
First file extension clash... @PeterKraus can I just check that `agilent-dx` is not just `jcamp-dx` in a trenchcoat?