### PR TITLE
Bump base image from Debian buster to bookworm

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-from python:3.11-slim-buster
+from python:3.11-slim-bookworm
 
 run apt-get update && apt-get install -y git && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
Tests failing in #30 as Debian buster is now out of support. This PR bumps our base image to bookworm.